### PR TITLE
Add SimpleAuthorization mechanism to the application

### DIFF
--- a/Backend/Framework.Sample.App/Authorization/Extensions/WebAppBuilderExtension.cs
+++ b/Backend/Framework.Sample.App/Authorization/Extensions/WebAppBuilderExtension.cs
@@ -3,6 +3,7 @@ using Framework.Sample.App.Authorization.AuthorizationStores;
 using Framework.Sample.App.Authorization.AuthorizationStores.Models;
 using Framework.Sample.App.Authorization.FeedDbBuilders;
 using Framework.Sample.App.Authorization.Implementations;
+using Framework.Sample.App.Authorization.SimpleAuthorization;
 using Framework.Sample.App.WebApplication;
 using Microsoft.AspNetCore.Authorization;
 using TCPOS.Lib.Authorization.Abstracts;
@@ -41,6 +42,7 @@ public static class WebAppBuilderExtension
         serviceCollection.AddScoped<ITcposAuthorizationManager, AuthorizationManagerErpReplace>();
         serviceCollection.AddScoped<ITcposAuthorizationManager, AuthorizationManagerErpUpdate>();
         serviceCollection.AddScoped<ITcposAuthorizationManager, AuthorizationManagerFormsEndpoints>();
+        serviceCollection.AddScoped<ITcposAuthorizationManager, AuthorizationManagerSimple>();
 
         serviceCollection.AddScoped<ITcposPermissionClaimsTransformationBuilder, PermissionClaimsTransformationBuilder>();
 
@@ -68,6 +70,7 @@ public static class WebAppBuilderExtension
         serviceCollection.AddSingleton<IFeedDatabaseManager<FeedDatabaseItem>, FeedDbBuilderErpReplace>();
         serviceCollection.AddSingleton<IFeedDatabaseManager<FeedDatabaseItem>, FeedDbBuilderErpUpdate>();
         serviceCollection.AddSingleton<IFeedDatabaseManager<FeedDatabaseItem>, FeedDbBuilderFormsEndpoints>();
+        serviceCollection.AddSingleton<IFeedDatabaseManager<FeedDatabaseItem>, FeedDbBuilderSimple>();
         serviceCollection.AddSingleton<IFeedDatabasePersister<FeedDatabaseItem>, FeedDatabasePersister>();
         serviceCollection.AddSingleton<IFeedDatabaseEngine, FeedDatabaseEngine<FeedDatabaseItem>>();
 

--- a/Backend/Framework.Sample.App/Authorization/SimpleAuthorization/AuthorizationManagerSimple.cs
+++ b/Backend/Framework.Sample.App/Authorization/SimpleAuthorization/AuthorizationManagerSimple.cs
@@ -1,0 +1,77 @@
+﻿using Framework.Sample.App.Authorization.AuthorizationManagers.Base;
+using Framework.Sample.App.Authorization.AuthorizationStores.Models;
+using Framework.Sample.App.DB.Enums;
+using Microsoft.AspNetCore.Authorization;
+using TCPOS.Lib.Authorization.Abstracts;
+using TCPOS.Lib.Authorization.Abstracts.AuthorizationStores;
+using TCPOS.Lib.Common.Diagnostics;
+using TCPOS.Lib.Authorization.Implementations;
+using System.Text.RegularExpressions;
+
+namespace Framework.Sample.App.Authorization.SimpleAuthorization;
+
+internal class AuthorizationManagerSimple(
+    IAuthorizationContextStore<AuthorizationHandlerContext> ctxStore,
+    IAuthorizationUserStore<AuthzUser, int> userStore,
+    IAuthorizationPermissionStore<AuthzPermission, int> permissionStore,
+    ITcposAuthorizationRepository<AuthzUser, AuthzGroup, AuthzPermission, AuthzPermissionValue, int> authorizationRepository)
+    : TcposAuthorizationManager<AuthzUser, AuthzGroup, AuthzPermission, AuthzPermissionValue, int>(ctxStore, userStore, permissionStore, authorizationRepository)
+{
+    /// <summary>
+    /// Returns true if the manager can handle the context
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="requirement"></param>
+    /// <returns></returns>
+    public override async Task<bool> CanHandleAsync(AuthorizationHandlerContext context, ITcposAuthorizationRequirement requirement)
+    {
+        Safety.Check(context != null, new ArgumentNullException(nameof(context)));
+        Safety.Check(requirement != null, new ArgumentNullException(nameof(requirement)));
+
+        var canHandle = context.Requirements?.OfType<AuthorizationRequirementSimple>().Any() ?? false ;
+
+        return await Task.FromResult(canHandle);
+    }
+
+    /// <summary>
+    /// returns true if the user is allowed for the permission
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="user"></param>
+    /// <param name="permission"></param>
+    /// <param name="requirement"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    protected override async Task<bool> IsRequirementAllowedAsync(AuthorizationHandlerContext context, AuthzUser? user, AuthzPermission? permission,
+                                                                  ITcposAuthorizationRequirement requirement, CancellationToken cancellationToken)
+    {
+        var isAllowed = false;
+        var permissionCode = GetPermissionCode(context, requirement);
+
+        if (isAllowed == false)
+        {
+            isAllowed = await base.IsRequirementAllowedAsync(context, user, permission, requirement, cancellationToken);
+        }
+
+        return isAllowed;
+    }
+
+    /// <summary>
+    /// Retrieve permission string from the context and requirement.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="requirement"></param>
+    /// <returns></returns>
+    protected override string GetPermission(HttpContext context, ITcposAuthorizationRequirement requirement)
+    {
+        var endpoint = context.GetEndpoint();
+        Safety.Check(endpoint != null, new ArgumentNullException(nameof(endpoint)));
+
+        var simpleRequirementAttribute = endpoint.Metadata.OfType<SimpleRequirementAttribute>()
+                                                  .FirstOrDefault();
+
+        Safety.Check(!string.IsNullOrEmpty(simpleRequirementAttribute?.AttributeName), "Attribute not defined");
+
+        return $"{simpleRequirementAttribute.AttributeName}-{PermissionTypes.Api}-{context.Request.Method}".ToLower();
+    }
+}

--- a/Backend/Framework.Sample.App/Authorization/SimpleAuthorization/AuthorizationRequirementSimple.cs
+++ b/Backend/Framework.Sample.App/Authorization/SimpleAuthorization/AuthorizationRequirementSimple.cs
@@ -1,0 +1,6 @@
+﻿using TCPOS.Lib.Authorization.Implementations;
+
+namespace Framework.Sample.App.Authorization.SimpleAuthorization;
+
+public class AuthorizationRequirementSimple : TcposAuthorizationRequirement
+{ }

--- a/Backend/Framework.Sample.App/Authorization/SimpleAuthorization/FeedDbBuilderSimple.cs
+++ b/Backend/Framework.Sample.App/Authorization/SimpleAuthorization/FeedDbBuilderSimple.cs
@@ -1,0 +1,59 @@
+﻿using Framework.Sample.App.Authorization.FeedDbBuilders;
+using Framework.Sample.App.DB.Enums;
+using Microsoft.AspNetCore.Authorization;
+using TCPOS.Lib.Authorization.FeedDatabase.Engine.Abstracts;
+using TCPOS.Lib.Common.Diagnostics;
+
+namespace Framework.Sample.App.Authorization.SimpleAuthorization;
+
+internal class FeedDbBuilderSimple : IFeedDatabaseManager<FeedDatabaseItem>
+{
+    /// <summary>
+    /// Returns true if the feeder can handle the endpoint
+    /// </summary>
+    /// <param name="endpoint"></param>
+    /// <returns></returns>
+    public async Task<bool> CanHandleAsync(Endpoint endpoint)
+    {
+        Safety.Check(endpoint != null, new ArgumentNullException(nameof(endpoint)));
+
+        var authorizationPolicy = endpoint.Metadata.OfType<AuthorizationPolicy>()
+                                          .FirstOrDefault();
+
+        var canHandle = authorizationPolicy?.Requirements.OfType<AuthorizationRequirementSimple>().Any() ?? false;
+        return await Task.FromResult(canHandle);
+    }
+
+    /// <summary>
+    /// Returns the list of permission to be added in the database
+    /// </summary>
+    /// <param name="endpoint"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task<IEnumerable<FeedDatabaseItem>> BuildFeedDatabaseItemsAsync(Endpoint endpoint, CancellationToken cancellationToken)
+    {
+        var methods = endpoint.Metadata.OfType<HttpMethodMetadata>().FirstOrDefault();
+
+        if (methods == null)
+        {
+            return [];
+        }
+
+        List<FeedDatabaseItem> items = [];
+
+        if (methods?.HttpMethods != null)
+        {
+            foreach (var method in methods.HttpMethods)
+            {
+                var simpleRequirementAttribute = endpoint.Metadata.OfType<SimpleRequirementAttribute>()
+                                                          .FirstOrDefault();
+
+                Safety.Check(!string.IsNullOrEmpty(simpleRequirementAttribute?.AttributeName), "Invalid simpleRequirementAttribute");
+
+                items.Add(new FeedDatabaseItem($"{simpleRequirementAttribute.AttributeName}-{PermissionTypes.Api}-{method}"));
+            }
+        }
+
+        return await Task.FromResult(items);
+    }
+}

--- a/Backend/Framework.Sample.App/Authorization/SimpleAuthorization/SimpleRequirementAttribute.cs
+++ b/Backend/Framework.Sample.App/Authorization/SimpleAuthorization/SimpleRequirementAttribute.cs
@@ -1,0 +1,12 @@
+﻿using Framework.Sample.App.DB.Entities;
+
+namespace Framework.Sample.App.Authorization.SimpleAuthorization;
+
+public class SimpleRequirementAttribute(string attributeName) : Attribute
+{
+    public string AttributeName
+    {
+        get;
+        set;
+    } = attributeName;
+}

--- a/Backend/Framework.Sample.App/WebApplication/WebApplicationFactory.cs
+++ b/Backend/Framework.Sample.App/WebApplication/WebApplicationFactory.cs
@@ -2,6 +2,7 @@
 using Framework.Sample.App.Authorization.DataPullOuts;
 using Framework.Sample.App.Authorization.Extensions;
 using Framework.Sample.App.Authorization.Requirements;
+using Framework.Sample.App.Authorization.SimpleAuthorization;
 using Framework.Sample.App.Configuration;
 using Framework.Sample.App.Data.Bind;
 using Framework.Sample.App.DB;
@@ -220,6 +221,11 @@ public static class WebApplicationFactory
 
         webApplication.MapPost("/api/{version}/formsendpoints", FormsEndpointsDelegates.SaveFormEndpoints)
                       .RequireTcposAuthorization<AuthorizationRequirementFormsEndpoints>();
+
+
+        webApplication.MapGet("api/simple", async () => DateTime.Now)
+            .WithMetadata(new SimpleRequirementAttribute("simpleAuthorization"))
+            .RequireTcposAuthorization<AuthorizationRequirementSimple>();
 
         webApplication.UseAuthorization();
     }


### PR DESCRIPTION
This commit introduces a new authorization strategy called `SimpleAuthorization`. Key changes include:

- Registration of `AuthorizationManagerSimple` and `FeedDbBuilderSimple` in `WebAppBuilderExtension.cs` to handle simple authorization requirements.
- Addition of a new endpoint (`/api/simple`) in `WebApplicationFactory.cs` that utilizes the `SimpleRequirementAttribute`.
- Creation of `AuthorizationManagerSimple` to implement specific authorization logic.
- Definition of `AuthorizationRequirementSimple` as a marker for simple requirements.
- Implementation of `FeedDbBuilderSimple` to manage feed database items based on simple authorization.
- Introduction of `SimpleRequirementAttribute` for defining simple authorization requirements on endpoints.