### PR TITLE
Update .gitignore and enhance HttpClientExtensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ AppPackages/
 **/appsettings.json
 **.zip
 **/.config/
+**/.vshistory/


### PR DESCRIPTION
- Added `.vshistory/` to `.gitignore` for Visual Studio files.
- Updated using directives in `HttpClientExtensions.cs` for better organization.
- Changed `serializerOptions` to a readonly field with C# 9.0 syntax.
- Introduced `TryReadAsStringAsync` for improved response handling in `HttpGetAsync`, `HttpPostAsync`, `HttpPutAsync`, and `HttpPatchAsync`.
- Updated return statements in the aforementioned methods to use the new response handling approach.
- Maintained existing functionality in `ToStringContent` and ensured `ToJson` uses the updated `serializerOptions`.